### PR TITLE
Add initial plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# App-specific:
+application.conf
+
+# sbt:
+target/
+
+# IDEs:
+.idea/
+.metals/
+.bloop/

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ application.conf
 
 # sbt:
 target/
+.scalafmt.conf
 
 # IDEs:
 .idea/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,9 +49,6 @@ pipeline {
         }
     }
     post {
-        always {
-            junit '**/target/test-reports/*'
-        }
         cleanup {
             cleanWs()
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,59 @@
+pipeline {
+    agent { label 'vault-token' }
+
+    options {
+        timestamps()
+        ansiColor('xterm')
+        disableConcurrentBuilds()
+    }
+    environment {
+        PATH = "${tool('vault')}:${tool('sbt')}:$PATH"
+        // Some wiring is broken between the custom-tools plugin and
+        // the pipeline plugin which prevents these vars from being
+        // injected when pulling in the custom 'vault' tool.
+        VAULT_ADDR = 'https://clotho.broadinstitute.org:8200'
+        VAULT_TOKEN_PATH = '/etc/vault-token-monster'
+    }
+    stages {
+        stage('Check formatting') {
+            steps {
+                sh 'sbt scalafmtCheckAll'
+            }
+        }
+        stage('Compile') {
+            steps {
+                sh 'sbt Compile/compile'
+            }
+        }
+        stage('Publish') {
+            when {
+                anyOf {
+                    branch 'master'
+                    tag pattern: 'v\\d.*', comparator: 'REGEXP'
+                }
+            }
+            steps {
+                script {
+                    def vaultPath = 'secret/dsp/accts/artifactory/dsdejenkins'
+                    def parts = [
+                            'set +x;',
+                            'echo Publishing to Artifactory...;',
+                            'export VAULT_TOKEN=$(cat $VAULT_TOKEN_PATH);',
+                            "ARTIFACTORY_USERNAME=\$(vault read -field=username $vaultPath)",
+                            "ARTIFACTORY_PASSWORD=\$(vault read -field=password $vaultPath)",
+                            'sbt publish'
+                    ]
+                    sh parts.join(' ')
+                }
+            }
+        }
+    }
+    post {
+        always {
+            junit '**/target/test-reports/*'
+        }
+        cleanup {
+            cleanWs()
+        }
+    }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,7 @@
 lazy val `monster-sbt-plugins` = project
   .in(file("."))
-  .settings(sbtPlugin := true)
+  .settings(
+    sbtPlugin := true,
+    addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.0.0"),
+    addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.4")
+  )

--- a/build.sbt
+++ b/build.sbt
@@ -4,5 +4,7 @@ lazy val `monster-sbt-plugins` = project
   .settings(
     sbtPlugin := true,
     addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.0.0"),
-    addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.4")
+    addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0"),
+    addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.4"),
+    addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0")
   )

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,3 @@
+lazy val `monster-sbt-plugins` = project
+  .in(file("."))
+  .settings(sbtPlugin := true)

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,6 @@
 lazy val `monster-sbt-plugins` = project
   .in(file("."))
+  .enablePlugins(LibraryPlugin)
   .settings(
     sbtPlugin := true,
     addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.0.0"),

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.0-RC4
+sbt.version=1.3.0

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.3.0-RC4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,4 +5,6 @@ Compile / unmanagedSourceDirectories +=
 
 // Needed for the dog-fooding setup, apparently.
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.0.0")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.4")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,4 @@
+// Spookiness: Use this project as its own plugins.
+// Lifted from here: https://github.com/scalacenter/sbt-release-early/blob/master/project/plugins.sbt
+Compile / unmanagedSourceDirectories +=
+  baseDirectory.value.getParentFile / "src" / "main" / "scala"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,3 +2,7 @@
 // Lifted from here: https://github.com/scalacenter/sbt-release-early/blob/master/project/plugins.sbt
 Compile / unmanagedSourceDirectories +=
   baseDirectory.value.getParentFile / "src" / "main" / "scala"
+
+// Needed for the dog-fooding setup, apparently.
+addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.0.0")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.4")

--- a/src/main/scala/org/broadinstitute/monster/sbt/LibraryPlugin.scala
+++ b/src/main/scala/org/broadinstitute/monster/sbt/LibraryPlugin.scala
@@ -1,0 +1,65 @@
+package org.broadinstitute.monster.sbt
+
+import sbt._
+import sbt.Keys._
+import sbtdynver.DynVerPlugin
+
+/**
+  * Plugin which should be applied to Monster sub-projects that need
+  * to be published as library jars for use in other projects.
+  */
+object LibraryPlugin extends AutoPlugin {
+  import DynVerPlugin.autoImport._
+
+  override def requires: Plugins = BasePlugin
+
+  /** Realm reported by our Artifactory instance. */
+  private val artifactoryRealm = "Artifactory Realm"
+
+  /** Hostname of our Artifactory instance. */
+  private val artifactoryHost = "broadinstitute.jfrog.io"
+
+  /** Environment variable expected to contain a username for our Artifactory. */
+  private val artifactoryUsernameVar = "ARTIFACTORY_USERNAME"
+
+  /** Environment variable expected to contain a password for our Artifactory. */
+  private val artifactoryPasswordVar = "ARTIFACTORY_PASSWORD"
+
+  /**
+    * Credentials which can authenticate the build tool with our Artifactory.
+    *
+    * We frame this as a setting so that it is loaded once at the start of the build,
+    * but within the proper DAG of settings set up by sbt.
+    */
+  private lazy val artifactoryCredentials = Def.setting {
+    val cred = for {
+      username <- sys.env.get(artifactoryUsernameVar)
+      password <- sys.env.get(artifactoryPasswordVar)
+    } yield {
+      Credentials(artifactoryRealm, artifactoryHost, username, password)
+    }
+
+    cred.orElse {
+      // SBT's logging comes from a task, and tasks can't be used inside settings, so we have to roll our own warning...
+      println(
+        s"[${scala.Console.YELLOW}warn${scala.Console.RESET}] $artifactoryUsernameVar or $artifactoryPasswordVar not set, publishing will fail!"
+      )
+      None
+    }
+  }
+
+  /** Maven-style resolver for our Artifactory instance. */
+  private lazy val artifactoryResolver = Def.task {
+    val target = if (isSnapshot.value) "snapshot" else "release"
+    artifactoryRealm at s"https://$artifactoryHost/broadinstitute/libs-$target-local"
+  }
+
+  override def buildSettings: Seq[Def.Setting[_]] = Seq(
+    dynverSonatypeSnapshots := true
+  )
+
+  override def projectSettings: Seq[Def.Setting[_]] = Seq(
+    publishTo := Some(artifactoryResolver.value),
+    credentials ++= artifactoryCredentials.value.toSeq
+  )
+}

--- a/src/main/scala/org/broadinstitute/monster/sbt/MonsterBasePlugin.scala
+++ b/src/main/scala/org/broadinstitute/monster/sbt/MonsterBasePlugin.scala
@@ -1,14 +1,38 @@
 package org.broadinstitute.monster.sbt
 
-import sbt._
+import org.scalafmt.sbt.ScalafmtPlugin
+import sbt.{Def, _}
 import sbt.Keys._
 import sbt.plugins.JvmPlugin
+import sbtdynver.DynVerPlugin
 
 object MonsterBasePlugin extends AutoPlugin {
+  import ScalafmtPlugin.autoImport._
 
   // Automatically apply our base settings to every project.
-  override def requires = JvmPlugin
+  override def requires = JvmPlugin && DynVerPlugin && ScalafmtPlugin
   override def trigger = allRequirements
+
+  val ScalafmtVersion = "2.1.0-RC1"
+
+  val ScalafmtConf: String =
+    s"""version = "$ScalafmtVersion"
+       |maxColumn = 90
+       |runner.optimizer.forceConfigStyleOnOffset = 90
+       |
+       |align = most
+       |align.openParenCallSite = false
+       |align.openParenDefnSite = false
+       |binPack.literalArgumentLists = false
+       |continuationIndent.callSite = 2
+       |continuationIndent.defnSite = 2
+       |danglingParentheses = true
+       |
+       |newlines.alwaysBeforeTopLevelStatements = true
+       |newlines.sometimesBeforeColonInMethodReturnType = false
+       |
+       |includeCurlyBraceInSelectChains = false
+       |""".stripMargin
 
   override def buildSettings: Seq[Def.Setting[_]] = Seq(
     organization := "org.broadinstitute.monster",
@@ -38,21 +62,30 @@ object MonsterBasePlugin extends AutoPlugin {
       "-Ywarn-numeric-widen",
       "-Ywarn-unused",
       "-Ywarn-value-discard"
-    )
+    ),
+    scalafmtConfig := {
+      val targetFile = (ThisBuild / baseDirectory).value / ".scalafmt.conf"
+      IO.write(targetFile, ScalafmtConf)
+      targetFile
+    },
+    scalafmtOnCompile := true
   )
 
   val BetterMonadicForVersion = "0.3.1"
 
   override def projectSettings: Seq[Def.Setting[_]] = Seq(
-    addCompilerPlugin("com.olegpy" %% "better-monadic-for" % BetterMonadicForVersion),
-    Compile / console / scalacOptions := (Compile / scalacOptions).value.filterNot(
-      Set(
-        "-Xfatal-warnings",
-        "-Xlint",
-        "-Ywarn-unused",
-        "-Ywarn-unused-import"
-      )
+    addCompilerPlugin(
+      "com.olegpy" %% "better-monadic-for" % BetterMonadicForVersion
     ),
+    Compile / console / scalacOptions := (Compile / scalacOptions).value
+      .filterNot(
+        Set(
+          "-Xfatal-warnings",
+          "-Xlint",
+          "-Ywarn-unused",
+          "-Ywarn-unused-import"
+        )
+      ),
     Compile / doc / scalacOptions += "-no-link-warnings",
     // Avoid classpath shenanigans by always forking a new JVM when running code.
     Runtime / fork := true,

--- a/src/main/scala/org/broadinstitute/monster/sbt/MonsterBasePlugin.scala
+++ b/src/main/scala/org/broadinstitute/monster/sbt/MonsterBasePlugin.scala
@@ -1,0 +1,61 @@
+package org.broadinstitute.monster.sbt
+
+import sbt._
+import sbt.Keys._
+import sbt.plugins.JvmPlugin
+
+object MonsterBasePlugin extends AutoPlugin {
+
+  // Automatically apply our base settings to every project.
+  override def requires = JvmPlugin
+  override def trigger = allRequirements
+
+  override def buildSettings: Seq[Def.Setting[_]] = Seq(
+    organization := "org.broadinstitute.monster",
+    scalaVersion := "2.12.8",
+    scalacOptions ++= Seq(
+      "-deprecation",
+      "-encoding",
+      "UTF-8",
+      "-explaintypes",
+      "-feature",
+      "-target:jvm-1.8",
+      "-unchecked",
+      "-Xcheckinit",
+      "-Xfatal-warnings",
+      "-Xfuture",
+      "-Xlint",
+      "-Xmax-classfile-name",
+      "200",
+      "-Yno-adapted-args",
+      "-Ypartial-unification",
+      "-Ywarn-dead-code",
+      "-Ywarn-extra-implicit",
+      "-Ywarn-inaccessible",
+      "-Ywarn-infer-any",
+      "-Ywarn-nullary-override",
+      "-Ywarn-nullary-unit",
+      "-Ywarn-numeric-widen",
+      "-Ywarn-unused",
+      "-Ywarn-value-discard"
+    )
+  )
+
+  val BetterMonadicForVersion = "0.3.1"
+
+  override def projectSettings: Seq[Def.Setting[_]] = Seq(
+    addCompilerPlugin("com.olegpy" %% "better-monadic-for" % BetterMonadicForVersion),
+    Compile / console / scalacOptions := (Compile / scalacOptions).value.filterNot(
+      Set(
+        "-Xfatal-warnings",
+        "-Xlint",
+        "-Ywarn-unused",
+        "-Ywarn-unused-import"
+      )
+    ),
+    Compile / doc / scalacOptions += "-no-link-warnings",
+    // Avoid classpath shenanigans by always forking a new JVM when running code.
+    Runtime / fork := true,
+    Test / fork := true
+  )
+}


### PR DESCRIPTION
Inspired by watching @benjamincarlin and @raaidbroad set up new GitHub repos and copy-paste a bunch of sbt settings.

The end goal is to set up a template repository, but to do so in a way that makes pushing out "global" build updates easy once a project has been created from the template. To set that up, we can first move all of our build boilerplate into custom sbt plugins, which we publish as a library. The eventual template will include a dependency on the plugins. Once a project is cut from the template, it can pull in updates by bumping the template version.

The other main plugins I'd like to add to this project are currently in Transporter:
* Generic Docker
* Docker + Helm
* DB migration helper

I'll port them over once this PR goes through