### PR TITLE
Revert to older scalafmt.

### DIFF
--- a/src/main/scala/org/broadinstitute/monster/sbt/BasePlugin.scala
+++ b/src/main/scala/org/broadinstitute/monster/sbt/BasePlugin.scala
@@ -27,7 +27,7 @@ object BasePlugin extends AutoPlugin {
     JvmPlugin && DynVerPlugin && ScalafmtPlugin && ScoverageSbtPlugin && BuildInfoPlugin
   override def trigger = allRequirements
 
-  val ScalafmtVersion = "2.1.0-RC1"
+  val ScalafmtVersion = "2.0.1"
 
   val ScalafmtConf: String =
     s"""version = "$ScalafmtVersion"


### PR DESCRIPTION
The newest scalafmt has some annoying regressions. We don't actually need any of the new features, so we can just stick with `2.0.X`