### PR TITLE
Bump versions and tweak compiler flags.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ lazy val `monster-sbt-plugins` = project
     sbtPlugin := true,
     addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.0.0"),
     addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0"),
-    addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.4"),
+    addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.5"),
     addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0"),
     // Maven-style publishing is unforgivingly broken for sbt plugins.
     // Override publishing to use ivy-style here.

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,5 +6,5 @@ Compile / unmanagedSourceDirectories +=
 // Needed for the dog-fooding setup, apparently.
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.0.0")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.4")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.5")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0")

--- a/src/main/scala/org/broadinstitute/monster/sbt/BasePlugin.scala
+++ b/src/main/scala/org/broadinstitute/monster/sbt/BasePlugin.scala
@@ -50,33 +50,45 @@ object BasePlugin extends AutoPlugin {
 
   override def buildSettings: Seq[Def.Setting[_]] = Seq(
     organization := "org.broadinstitute.monster",
-    scalaVersion := "2.12.8",
-    scalacOptions ++= Seq(
-      "-deprecation",
-      "-encoding",
-      "UTF-8",
-      "-explaintypes",
-      "-feature",
-      "-target:jvm-1.8",
-      "-unchecked",
-      "-Xcheckinit",
-      "-Xfatal-warnings",
-      "-Xfuture",
-      "-Xlint",
-      "-Xmax-classfile-name",
-      "200",
-      "-Yno-adapted-args",
-      "-Ypartial-unification",
-      "-Ywarn-dead-code",
-      "-Ywarn-extra-implicit",
-      "-Ywarn-inaccessible",
-      "-Ywarn-infer-any",
-      "-Ywarn-nullary-override",
-      "-Ywarn-nullary-unit",
-      "-Ywarn-numeric-widen",
-      "-Ywarn-unused",
-      "-Ywarn-value-discard"
-    ),
+    scalaVersion := "2.12.10",
+    scalacOptions ++= {
+      val snapshot = isSnapshot.value
+      val base = Seq(
+        "-deprecation",
+        "-encoding",
+        "UTF-8",
+        "-explaintypes",
+        "-feature",
+        "-target:jvm-1.8",
+        "-unchecked",
+        "-Xfatal-warnings",
+        "-Xfuture",
+        "-Xlint",
+        "-Xmax-classfile-name",
+        "200",
+        "-Yno-adapted-args",
+        "-Ypartial-unification",
+        "-Ywarn-dead-code",
+        "-Ywarn-extra-implicit",
+        "-Ywarn-inaccessible",
+        "-Ywarn-infer-any",
+        "-Ywarn-nullary-override",
+        "-Ywarn-nullary-unit",
+        "-Ywarn-numeric-widen",
+        "-Ywarn-unused",
+        "-Ywarn-value-discard"
+      )
+
+      if (snapshot) {
+        // -Xcheckinit adds extra synchronization logic / null checks to every
+        // field access. It's awesome for catching problems with initialization
+        // order when doing weird things with inheritance, but it can have
+        // nontrivial performance impact, so we only enable it for SNAPSHOT builds.
+        base :+ "-Xcheckinit"
+      } else {
+        base
+      }
+    },
     scalafmtConfig := {
       val targetFile = (ThisBuild / baseDirectory).value / ".scalafmt.conf"
       IO.write(targetFile, ScalafmtConf)


### PR DESCRIPTION
* Bump to latest patch version of Scala 2.12
* Bump scalafmt plugin version
* Tweak how we set compiler flags to be a little more optimal when publishing "official" versions