### PR TITLE
DSPDC-794 Update "latest" tag whenever publishing a Docker image.

### DIFF
--- a/plugins/core/src/main/scala/org/broadinstitute/monster/sbt/MonsterDockerPlugin.scala
+++ b/plugins/core/src/main/scala/org/broadinstitute/monster/sbt/MonsterDockerPlugin.scala
@@ -28,6 +28,8 @@ object MonsterDockerPlugin extends AutoPlugin with LinuxKeys with NativePackager
     // volumes are chmod-ed to be writeable only by "root").
     Docker / daemonUserUid := None,
     Docker / daemonUser := "root",
+    // Publish "latest" tag to make coordinating versions in dev simpler.
+    dockerUpdateLatest := true,
     // Make our CI life easier and set up publish delegation here.
     publish := (Docker / publish).value,
     publishLocal := (Docker / publishLocal).value


### PR DESCRIPTION
By publishing a "latest" tag, we can have our Argo charts default to running that tag (for dev), with the option of overriding a specific version (for prod).