### PR TITLE
DSPDC-794 Switch to Graal for Docker base image.

### DIFF
--- a/plugins/core/src/main/scala/org/broadinstitute/monster/sbt/MonsterDockerPlugin.scala
+++ b/plugins/core/src/main/scala/org/broadinstitute/monster/sbt/MonsterDockerPlugin.scala
@@ -17,7 +17,7 @@ object MonsterDockerPlugin extends AutoPlugin with LinuxKeys with NativePackager
   override def requires = DockerPlugin && AshScriptPlugin && MonsterBasePlugin
 
   override def projectSettings: Seq[Def.Setting[_]] = Seq(
-    dockerBaseImage := "openjdk:8-alpine",
+    dockerBaseImage := "oracle/graalvm-ce:20.0.0-java8",
     dockerRepository := Some("us.gcr.io/broad-dsp-gcr-public"),
     dockerLabels := Map("VERSION" -> version.value),
     Docker / defaultLinuxInstallLocation := "/app",


### PR DESCRIPTION
Attempting to launch the ClinVar dataflow pipeline from Argo threw this error:
```
Exception in thread "main" java.lang.UnsatisfiedLinkError: /tmp/snappy-1.1.4-ef481b98-4060-4b0a-9e53-0328043b25e3-libsnappyjava.so: Error loading shared library ld-linux-x86-64.so.2: No such file or directory (needed by /tmp/snappy-1.1.4-ef481b98-4060-4b0a-9e53-0328043b25e3-libsnappyjava.so)
```
The relevant piece being:
```
Error loading shared library ld-linux-x86-64.so.2: No such file or directory
```
[This stackoverflow](https://stackoverflow.com/questions/50288034/unsatisfiedlinkerror-tmp-snappy-1-1-4-libsnappyjava-so-error-loading-shared-li/51655643#51655643) says that Alpine is the root cause of the error.

Instead of following that answer's advice (building a custom Docker w/ compatibility libraries installed), this swaps the base image we use to GraalVM's. [Graal](https://www.graalvm.org/) is an alternate JVM that boasts to be faster than the "standard" Oracle or Open JDKs. It also supports compiling Java code down to statically-linked binaries a la Go, which could be interesting for us to explore in the future. I've been using Graal as my local JVM for ~6 months without problems. I've confirmed that `/lib64/ld-linux-x86-64.so.2` exists in the image.