### PR TITLE
DSPDC-891 Extend Jade plugin to publish Dockers with BQ metadata

### DIFF
--- a/plugins/jade/src/main/scala/org/broadinstitute/monster/sbt/BigQueryMetadataGenerator.scala
+++ b/plugins/jade/src/main/scala/org/broadinstitute/monster/sbt/BigQueryMetadataGenerator.scala
@@ -1,0 +1,91 @@
+package org.broadinstitute.monster.sbt
+
+import java.nio.file.Path
+
+import io.circe.jawn.JawnParser
+import io.circe.syntax._
+import org.broadinstitute.monster.sbt.model.ColumnType.{Optional, _}
+import org.broadinstitute.monster.sbt.model.bigquery.BigQueryColumn
+import org.broadinstitute.monster.sbt.model.{MonsterTable, SimpleColumn}
+import sbt._
+import sbt.internal.util.ManagedLogger
+import sbt.nio.file.{FileAttributes, FileTreeView}
+
+/** Utilities for generating BigQuery metadata from Monster table definitions. */
+object BigQueryMetadataGenerator {
+  private val jsonParser: JawnParser = new JawnParser()
+
+  type BigQueryTable = Seq[BigQueryColumn]
+
+  /**
+    * Generate BigQuery metadata files based on the table definitions
+    * located in a local directory.
+    *
+    * @param inputDir directory containing table definitions in our JSON format
+    * @param inputExtension file extension used for our table definitions
+    * @param outputDir directory where BQ metadata files should be written
+    * @param fileView utility which can inspect the local filesystem
+    * @param logger utility which can write logs to the sbt console
+    */
+  def generateMetadata(
+    inputDir: File,
+    inputExtension: String,
+    outputDir: File,
+    fileView: FileTreeView[(Path, FileAttributes)],
+    logger: ManagedLogger
+  ): Seq[File] = {
+    val sourcePattern = inputDir.toGlob / s"*.$inputExtension"
+    val sourceTables = fileView.list(sourcePattern).map {
+      case (path, _) =>
+        jsonParser
+          .decodeFile[MonsterTable](path.toFile)
+          .fold(err => sys.error(err.getMessage), identity)
+    }
+
+    sourceTables.flatMap { table =>
+      logger.info(s"Generating BigQuery metadata for table ${table.name}")
+      val schema = tableSchema(table)
+      val pkCols = primaryKeyColumns(table)
+      val compareCols = nonPrimaryKeyColumns(table)
+
+      val out = outputDir / table.name.id
+      val schemaOut = out / "schema.json"
+      val pkOut = out / "primary-keys"
+      val compareOut = out / "compare-cols"
+
+      out.mkdirs()
+      IO.write(schemaOut, schema.asJson.noSpaces)
+      IO.write(pkOut, pkCols.mkString(","))
+      IO.write(compareOut, compareCols.mkString(","))
+      logger.info(s"Wrote BigQuery metadata to ${out.getAbsolutePath}")
+
+      Seq(schemaOut, pkOut, compareOut)
+    }
+  }
+
+  /** Get a BigQuery schema describing the columns of one of our tables. */
+  def tableSchema(table: MonsterTable): BigQueryTable =
+    table.columns.map { column =>
+      BigQueryColumn(
+        name = column.name.id,
+        `type` = column.datatype.asBigQuery,
+        mode = column.`type`.asBigQuery
+      )
+    }
+
+  /** Get the names of all primary-key columns in one of our tables. */
+  def primaryKeyColumns(table: MonsterTable): Seq[String] =
+    table.columns.collect {
+      case SimpleColumn(name, _, PrimaryKey, _) => name.id
+    }
+
+  /** Get the names of all non-primary-key columns in one of our tables. */
+  def nonPrimaryKeyColumns(table: MonsterTable): Seq[String] = {
+    val simpleCols = table.columns.collect {
+      case SimpleColumn(name, _, Required | Repeated | Optional, _) => name.id
+    }
+    val structCols = table.structColumns.map(_.name.id)
+
+    simpleCols ++ structCols
+  }
+}

--- a/plugins/jade/src/main/scala/org/broadinstitute/monster/sbt/BigQueryMetadataGenerator.scala
+++ b/plugins/jade/src/main/scala/org/broadinstitute/monster/sbt/BigQueryMetadataGenerator.scala
@@ -57,7 +57,7 @@ object BigQueryMetadataGenerator {
       IO.write(schemaOut, schema.asJson.noSpaces)
       IO.write(pkOut, pkCols.mkString(","))
       IO.write(compareOut, compareCols.mkString(","))
-      logger.info(s"Wrote BigQuery metadata to ${out.getAbsolutePath}")
+      logger.info(s"Wrote BigQuery metadata to ${out.getAbsolutePath}/")
 
       Seq(schemaOut, pkOut, compareOut)
     }

--- a/plugins/jade/src/main/scala/org/broadinstitute/monster/sbt/BigQueryMetadataGenerator.scala
+++ b/plugins/jade/src/main/scala/org/broadinstitute/monster/sbt/BigQueryMetadataGenerator.scala
@@ -48,6 +48,8 @@ object BigQueryMetadataGenerator {
       val pkCols = primaryKeyColumns(table)
       val compareCols = nonPrimaryKeyColumns(table)
 
+      // Clean the directory before generating anything.
+      IO.delete(outputDir)
       val out = outputDir / table.name.id
       val schemaOut = out / "schema.json"
       val pkOut = out / "primary-keys"
@@ -64,14 +66,23 @@ object BigQueryMetadataGenerator {
   }
 
   /** Get a BigQuery schema describing the columns of one of our tables. */
-  def tableSchema(table: MonsterTable): BigQueryTable =
-    table.columns.map { column =>
+  def tableSchema(table: MonsterTable): BigQueryTable = {
+    val simpleColumns = table.columns.map { column =>
       BigQueryColumn(
         name = column.name.id,
         `type` = column.datatype.asBigQuery,
         mode = column.`type`.asBigQuery
       )
     }
+    val structColumns = table.structColumns.map { column =>
+      BigQueryColumn(
+        name = column.name.id,
+        `type` = "STRING",
+        mode = column.`type`.asBigQuery
+      )
+    }
+    simpleColumns ++ structColumns
+  }
 
   /** Get the names of all primary-key columns in one of our tables. */
   def primaryKeyColumns(table: MonsterTable): Seq[String] =

--- a/plugins/jade/src/main/scala/org/broadinstitute/monster/sbt/JadeDatasetGenerator.scala
+++ b/plugins/jade/src/main/scala/org/broadinstitute/monster/sbt/JadeDatasetGenerator.scala
@@ -1,17 +1,62 @@
 package org.broadinstitute.monster.sbt
 
+import java.nio.file.Path
+
+import io.circe.jawn.JawnParser
+import io.circe.syntax._
+import sbt._
 import java.util.UUID
 
-import org.broadinstitute.monster.sbt.model.{
-  ColumnType,
-  DataType,
-  JadeIdentifier,
-  MonsterTable
-}
+import org.broadinstitute.monster.sbt.model._
 import org.broadinstitute.monster.sbt.model.jadeapi._
+import sbt.internal.util.ManagedLogger
+import sbt.nio.file.{FileAttributes, FileTreeView}
 
 /** Utilities for generating Jade dataset definitions from Monster table definitions. */
 object JadeDatasetGenerator {
+  private val jsonParser: JawnParser = new JawnParser()
+
+  /**
+   * Generate a JSON file containing a Jade dataset definition based on
+   * the table definitions located in a local directory.
+   *
+   * @param name unique ID for the dataset
+   * @param description human-friendly description for the dataset
+   * @param profileId ID of the resource/billing profile the dataset should use
+   * @param inputDir directory containing table definitions in our JSON format
+   * @param inputExtension file extension used for our table definitions
+   * @param outputDir directory where the Jade dataset request should be written
+   * @param fileView utility which can inspect the local filesystem
+   * @param logger utility which can write logs to the sbt console
+   */
+  def generateDataset(
+    name: JadeIdentifier,
+    description: String,
+    profileId: UUID,
+    inputDir: File,
+    inputExtension: String,
+    outputDir: File,
+    fileView: FileTreeView[(Path, FileAttributes)],
+    logger: ManagedLogger
+  ): File = {
+    val sourcePattern = inputDir.toGlob / s"*.$inputExtension"
+    val sourceTables = fileView.list(sourcePattern).map {
+      case (path, _) =>
+        jsonParser
+          .decodeFile[MonsterTable](path.toFile)
+          .fold(err => sys.error(err.getMessage), identity)
+    }
+
+    logger.info(s"Generating Jade schema from ${sourceTables.length} input tables")
+    generateDataset(name, description, profileId, sourceTables) match {
+      case Left(err) => sys.error(err)
+      case Right(datasetModel) =>
+        val out = outputDir / s"$name.dataset.json"
+        IO.write(out, datasetModel.asJson.noSpaces)
+        logger.info(s"Wrote Jade schema to ${out.getAbsolutePath}")
+        out
+    }
+  }
 
   /**
     * Generate a Jade dataset from a collection of Monster tables.

--- a/plugins/jade/src/main/scala/org/broadinstitute/monster/sbt/JadeDatasetGenerator.scala
+++ b/plugins/jade/src/main/scala/org/broadinstitute/monster/sbt/JadeDatasetGenerator.scala
@@ -17,18 +17,18 @@ object JadeDatasetGenerator {
   private val jsonParser: JawnParser = new JawnParser()
 
   /**
-   * Generate a JSON file containing a Jade dataset definition based on
-   * the table definitions located in a local directory.
-   *
-   * @param name unique ID for the dataset
-   * @param description human-friendly description for the dataset
-   * @param profileId ID of the resource/billing profile the dataset should use
-   * @param inputDir directory containing table definitions in our JSON format
-   * @param inputExtension file extension used for our table definitions
-   * @param outputDir directory where the Jade dataset request should be written
-   * @param fileView utility which can inspect the local filesystem
-   * @param logger utility which can write logs to the sbt console
-   */
+    * Generate a JSON file containing a Jade dataset definition based on
+    * the table definitions located in a local directory.
+    *
+    * @param name unique ID for the dataset
+    * @param description human-friendly description for the dataset
+    * @param profileId ID of the resource/billing profile the dataset should use
+    * @param inputDir directory containing table definitions in our JSON format
+    * @param inputExtension file extension used for our table definitions
+    * @param outputDir directory where the Jade dataset request should be written
+    * @param fileView utility which can inspect the local filesystem
+    * @param logger utility which can write logs to the sbt console
+    */
   def generateDataset(
     name: JadeIdentifier,
     description: String,

--- a/plugins/jade/src/main/scala/org/broadinstitute/monster/sbt/MonsterJadeDatasetKeys.scala
+++ b/plugins/jade/src/main/scala/org/broadinstitute/monster/sbt/MonsterJadeDatasetKeys.scala
@@ -45,4 +45,10 @@ trait MonsterJadeDatasetKeys {
   val generateJadeDataset: InputKey[File] = inputKey(
     "Generate JSON definition of a Jade dataset containing table definitions in this project"
   )
+
+  val bigQueryMetadataTarget: SettingKey[File] =
+    settingKey("Directory where generated BigQuery metadata should be written")
+
+  val generateBigQueryMetadata: TaskKey[Seq[File]] =
+    taskKey("Generate BigQuery metadata files for table definitions in this project")
 }

--- a/plugins/jade/src/main/scala/org/broadinstitute/monster/sbt/MonsterJadeDatasetPlugin.scala
+++ b/plugins/jade/src/main/scala/org/broadinstitute/monster/sbt/MonsterJadeDatasetPlugin.scala
@@ -79,6 +79,7 @@ object MonsterJadeDatasetPlugin extends AutoPlugin with LinuxKeys {
     ),
     // Override the Docker image to use gcloud, so we get access to 'bq'.
     dockerBaseImage := "google/cloud-sdk:283.0.0-slim",
+    dockerEntrypoint := Seq("bq"),
     // Write local files into the /schemas directory.
     Docker / defaultLinuxInstallLocation := "/bq-metadata",
     // Rewire the Docker mappings to only add generated metadata files.

--- a/plugins/jade/src/main/scala/org/broadinstitute/monster/sbt/MonsterJadeDatasetPlugin.scala
+++ b/plugins/jade/src/main/scala/org/broadinstitute/monster/sbt/MonsterJadeDatasetPlugin.scala
@@ -1,115 +1,41 @@
 package org.broadinstitute.monster.sbt
 
-import java.nio.file.{Files, Path}
 import java.util.UUID
 
-import io.circe.syntax._
-import io.circe.jawn.JawnParser
-import org.broadinstitute.monster.sbt.model.MonsterTable
+import com.typesafe.sbt.packager.MappingsHelper
+import com.typesafe.sbt.packager.linux.LinuxKeys
 import sbt._
 import sbt.Keys._
 import sbt.complete.Parser
 import sbt.complete.DefaultParsers._
-import sbt.internal.util.ManagedLogger
 import sbt.nio.Keys._
-import sbt.nio.file.{FileAttributes, FileTreeView}
 
 /** Plugin for projects which ETL data into a Jade dataset. */
-object MonsterJadeDatasetPlugin extends AutoPlugin {
-  override def requires: Plugins = MonsterBasePlugin
+object MonsterJadeDatasetPlugin extends AutoPlugin with LinuxKeys {
+  import com.typesafe.sbt.packager.docker.DockerPlugin.autoImport._
+  import com.typesafe.sbt.packager.universal.UniversalPlugin.autoImport._
+
+  override def requires: Plugins = MonsterDockerPlugin
 
   object autoImport extends MonsterJadeDatasetKeys
   import autoImport._
 
   private val uuidParser: Parser[UUID] = mapOrFail(NotSpace)(UUID.fromString)
-  private val jsonParser: JawnParser = new JawnParser()
 
   // We inject circe as a dependency so we can include serialization
   // logic within generated source code.
   val CirceVersion = "0.12.3"
   val CirceDerivationVersion = "0.12.0-M7"
 
-  /**
-    * Convert the contents of a local (non-Scala) file into Scala source code.
-    *
-    * The actual class-generation logic is passed into this method as an argument.
-    * This method is useful because it provides common caching logic using sbt's
-    * build-in file watching capabilities, re-generating classes only when their
-    * source files change. Most of the logic here is copy-pasted from docs:
-    * https://www.scala-sbt.org/1.x/docs/Howto-Track-File-Inputs-and-Outputs.html#File+inputs
-    *
-    * @param inputFiles list of files on disk which should be converted into Scala
-    *                   source files
-    * @param inputChanges description of filesystem changes since the last time
-    *                     the task was triggered
-    * @param inputExtension common file extension for each input file
-    * @param outputDir directory where generated Scala classes should be written
-    * @param fileView utility which can inspect the local filesystem
-    * @param logger utility which can write logs to the sbt console
-    * @param gen function which can convert input file contents to Scala source code
-    */
-  private def generateClasses(
-    inputFiles: Seq[Path],
-    inputChanges: FileChanges,
-    inputExtension: String,
-    outputDir: Path,
-    fileView: FileTreeView[(Path, FileAttributes)],
-    logger: ManagedLogger,
-    gen: String => Either[Throwable, String]
-  ): Seq[File] = {
-    def outputPath(path: Path): Path =
-      outputDir / path.getFileName.toString.replaceAll(s".$inputExtension$$", ".scala")
-
-    def generate(path: Path): Path = {
-      val input = new String(Files.readAllBytes(path))
-      val output = outputPath(path)
-      logger.info(s"Generating $output from $path")
-      gen(input) match {
-        case Left(err) =>
-          logger.trace(err)
-          sys.error(s"Failed to generate $output from $path")
-        case Right(codeString) =>
-          Files.createDirectories(output.getParent)
-          Files.write(output, codeString.getBytes())
-      }
-      output
-    }
-
-    // Build a mapping from expected-output-path -> source-input-path.
-    val sourceMap = inputFiles.view.map(p => outputPath(p) -> p).toMap
-
-    // Delete any files that exist in the output directory but don't
-    // have a corresponding source file.
-    val existingTargets = fileView
-      .list(outputDir.toGlob / **)
-      .flatMap {
-        case (p, _) =>
-          if (!sourceMap.contains(p)) {
-            Files.deleteIfExists(p)
-            None
-          } else {
-            Some(p)
-          }
-      }
-      .toSet
-
-    // Re-generate classes for new and updated source files.
-    val toGenerate = (inputChanges.created ++ inputChanges.modified).toSet ++ sourceMap
-      .filterKeys(!existingTargets.contains(_))
-      .values
-    toGenerate.foreach(generate)
-    sourceMap.keys.toVector.map(_.toFile)
-  }
-
   override def projectSettings: Seq[Def.Setting[_]] = Seq(
     libraryDependencies ++= Seq(
       "io.circe" %% "circe-core" % CirceVersion,
       "io.circe" %% "circe-derivation" % CirceDerivationVersion
     ),
-    jadeTableSource := sourceDirectory.value / "jade-schema" / "tables",
+    jadeTableSource := sourceDirectory.value / "main" / "jade-tables",
     jadeTableExtension := "table.json",
     jadeTableTarget := (Compile / sourceManaged).value / "jade-schema" / "tables",
-    jadeStructSource := sourceDirectory.value / "jade-schema" / "structs",
+    jadeStructSource := sourceDirectory.value / "main" / "jade-structs",
     jadeStructExtension := "struct.json",
     jadeStructTarget := (Compile / sourceManaged).value / "jade-schema" / "structs",
     Compile / managedSourceDirectories ++= Seq(
@@ -122,7 +48,7 @@ object MonsterJadeDatasetPlugin extends AutoPlugin {
     ),
     generateJadeTables / fileInputs += jadeTableSource.value.toGlob / s"*.${jadeTableExtension.value}",
     generateJadeStructs / fileInputs += jadeStructSource.value.toGlob / s"*.${jadeStructExtension.value}",
-    generateJadeTables := generateClasses(
+    generateJadeTables := ClassGenerator.generateClasses(
       inputFiles = generateJadeTables.inputFiles,
       inputChanges = generateJadeTables.inputFileChanges,
       inputExtension = jadeTableExtension.value,
@@ -132,7 +58,7 @@ object MonsterJadeDatasetPlugin extends AutoPlugin {
       gen = ClassGenerator
         .generateTableClass(jadeTablePackage.value, jadeStructPackage.value, _)
     ),
-    generateJadeStructs := generateClasses(
+    generateJadeStructs := ClassGenerator.generateClasses(
       inputFiles = generateJadeStructs.inputFiles,
       inputChanges = generateJadeStructs.inputFileChanges,
       inputExtension = jadeStructExtension.value,
@@ -141,33 +67,33 @@ object MonsterJadeDatasetPlugin extends AutoPlugin {
       logger = streams.value.log,
       gen = ClassGenerator.generateStructClass(jadeStructPackage.value, _)
     ),
-    generateJadeDataset := {
-      val log = streams.value.log
-
-      val profileId = (token(Space) ~> token(uuidParser, "<profile-id>")).parsed
-      val name = jadeDatasetName.value
-      val description = jadeDatasetDescription.value
-
-      val sourcePattern = jadeTableSource.value.toGlob / s"*.${jadeTableExtension.value}"
-      val sourceTables = FileTreeView.default.list(sourcePattern).map {
-        case (path, _) =>
-          jsonParser
-            .decodeFile[MonsterTable](path.toFile)
-            .fold(err => sys.error(err.getMessage), identity)
-      }
-
-      log.info(s"Generating Jade schema from ${sourceTables.length} input tables...")
-      JadeDatasetGenerator
-        .generateDataset(name, description, profileId, sourceTables)
-        .fold(
-          sys.error,
-          datasetModel => {
-            val out = target.value / s"$name.dataset.json"
-            IO.write(out, datasetModel.asJson.noSpaces)
-            log.info(s"Wrote Jade schema to ${out.getAbsolutePath}")
-            out
-          }
-        )
-    }
+    generateJadeDataset := JadeDatasetGenerator.generateDataset(
+      name = jadeDatasetName.value,
+      description = jadeDatasetDescription.value,
+      profileId = (token(Space) ~> token(uuidParser, "<profile-id>")).parsed,
+      inputDir = jadeTableSource.value,
+      inputExtension = jadeTableExtension.value,
+      outputDir = target.value,
+      fileView = fileTreeView.value,
+      logger = streams.value.log
+    ),
+    // Override the Docker image to use gcloud, so we get access to 'bq'.
+    dockerBaseImage := "google/cloud-sdk:283.0.0-slim",
+    // Write local files into the /schemas directory.
+    Docker / defaultLinuxInstallLocation := "/bq-metadata",
+    // Rewire the Docker mappings to only add generated metadata files.
+    bigQueryMetadataTarget := target.value / "bq",
+    Universal / mappings := {
+      val dir = bigQueryMetadataTarget.value
+      val metadataFiles = generateBigQueryMetadata.value
+      metadataFiles.pair(MappingsHelper.relativeTo(dir))
+    },
+    generateBigQueryMetadata := BigQueryMetadataGenerator.generateMetadata(
+      inputDir = jadeTableSource.value,
+      inputExtension = jadeTableExtension.value,
+      outputDir = bigQueryMetadataTarget.value,
+      fileView = fileTreeView.value,
+      logger = streams.value.log
+    )
   )
 }

--- a/plugins/jade/src/main/scala/org/broadinstitute/monster/sbt/model/ColumnType.scala
+++ b/plugins/jade/src/main/scala/org/broadinstitute/monster/sbt/model/ColumnType.scala
@@ -12,6 +12,9 @@ sealed trait ColumnType extends EnumEntry with Snakecase {
     * a modified (fully-qualified) Scala class based on the type.
     */
   def modify(scalaType: String): String
+
+  /** Name of the BigQuery mode that the column type will map to. */
+  def asBigQuery: String
 }
 
 object ColumnType extends Enum[ColumnType] with CirceEnum[ColumnType] {
@@ -24,11 +27,13 @@ object ColumnType extends Enum[ColumnType] with CirceEnum[ColumnType] {
     */
   case object PrimaryKey extends ColumnType {
     override def modify(scalaType: String): String = scalaType
+    override val asBigQuery: String = "REQUIRED"
   }
 
   /** Marker for non-optional columns. */
   case object Required extends ColumnType {
     override def modify(scalaType: String): String = scalaType
+    override val asBigQuery: String = "REQUIRED"
   }
 
   /** Marker for optional columns. */
@@ -36,6 +41,7 @@ object ColumnType extends Enum[ColumnType] with CirceEnum[ColumnType] {
 
     override def modify(scalaType: String): String =
       s"_root_.scala.Option[$scalaType]"
+    override val asBigQuery: String = "NULLABLE"
   }
 
   /** Marker for columns which contain arrays. */
@@ -43,5 +49,6 @@ object ColumnType extends Enum[ColumnType] with CirceEnum[ColumnType] {
 
     override def modify(scalaType: String): String =
       s"_root_.scala.Array[$scalaType]"
+    override val asBigQuery: String = "REPEATED"
   }
 }

--- a/plugins/jade/src/main/scala/org/broadinstitute/monster/sbt/model/DataType.scala
+++ b/plugins/jade/src/main/scala/org/broadinstitute/monster/sbt/model/DataType.scala
@@ -9,6 +9,9 @@ import scala.collection.immutable.IndexedSeq
 sealed trait DataType extends EnumEntry with Snakecase {
   /** Fully-qualified name of the Scala class corresponding to the Jade type. */
   def asScala: String
+
+  /** Name of the BQ type that the Jade type will map to. */
+  def asBigQuery: String
 }
 
 object DataType extends Enum[DataType] with CirceEnum[DataType] {
@@ -22,18 +25,22 @@ object DataType extends Enum[DataType] with CirceEnum[DataType] {
   // BigDecimals, but again we haven't needed it yet.
   case object Boolean extends DataType {
     override val asScala: String = "_root_.scala.Boolean"
+    override val asBigQuery: String = "BOOL"
   }
 
   case object Float extends DataType {
     override val asScala: String = "_root_.scala.Double"
+    override val asBigQuery: String = "FLOAT64"
   }
 
   case object Integer extends DataType {
     override val asScala: String = "_root_.scala.Long"
+    override val asBigQuery: String = "INT64"
   }
 
   case object String extends DataType {
     override val asScala: String = "_root_.java.lang.String"
+    override val asBigQuery: String = "STRING"
   }
 
   // Time-related column types.
@@ -42,18 +49,22 @@ object DataType extends Enum[DataType] with CirceEnum[DataType] {
   // these two options.
   case object Date extends DataType {
     override val asScala: String = "_root_.java.time.LocalDate"
+    override val asBigQuery: String = "DATE"
   }
 
   case object Timestamp extends DataType {
     override val asScala: String = "_root_.java.time.OffsetDateTime"
+    override val asBigQuery: String = "TIMESTAMP"
   }
 
   // Jade-specific column types.
   case object DirRef extends DataType {
     override val asScala: String = "_root_.java.lang.String"
+    override val asBigQuery: String = "STRING"
   }
 
   case object FileRef extends DataType {
     override val asScala: String = "_root_.java.lang.String"
+    override val asBigQuery: String = "STRING"
   }
 }

--- a/plugins/jade/src/main/scala/org/broadinstitute/monster/sbt/model/bigquery/BigQueryColumn.scala
+++ b/plugins/jade/src/main/scala/org/broadinstitute/monster/sbt/model/bigquery/BigQueryColumn.scala
@@ -1,0 +1,10 @@
+package org.broadinstitute.monster.sbt.model.bigquery
+
+import io.circe.Encoder
+import io.circe.derivation.deriveEncoder
+
+case class BigQueryColumn(name: String, `type`: String, mode: String)
+
+object BigQueryColumn {
+  implicit val encoder: Encoder[BigQueryColumn] = deriveEncoder
+}

--- a/plugins/jade/src/main/scala/org/broadinstitute/monster/sbt/model/jadeapi/JadeSchema.scala
+++ b/plugins/jade/src/main/scala/org/broadinstitute/monster/sbt/model/jadeapi/JadeSchema.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.monster.sbt.model.jadeapi
 
-import io.circe.{Encoder, Json}
+import io.circe.Encoder
 import io.circe.derivation.deriveEncoder
 
 case class JadeSchema(
@@ -9,7 +9,5 @@ case class JadeSchema(
 )
 
 object JadeSchema {
-
-  implicit val encoder: Encoder[JadeSchema] =
-    deriveEncoder.mapJsonObject(_.add("assets", Json.arr()))
+  implicit val encoder: Encoder[JadeSchema] = deriveEncoder
 }

--- a/plugins/jade/src/test/scala/org/broadinstitute/monster/sbt/BigQueryMetadataGeneratorSpec.scala
+++ b/plugins/jade/src/test/scala/org/broadinstitute/monster/sbt/BigQueryMetadataGeneratorSpec.scala
@@ -1,0 +1,80 @@
+package org.broadinstitute.monster.sbt
+
+import org.broadinstitute.monster.sbt.model._
+import org.broadinstitute.monster.sbt.model.bigquery.BigQueryColumn
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class BigQueryMetadataGeneratorSpec extends AnyFlatSpec with Matchers {
+
+  private val exampleTable = MonsterTable(
+    name = new JadeIdentifier("file"),
+    columns = Vector(
+      SimpleColumn(
+        name = new JadeIdentifier("sample_id"),
+        datatype = DataType.String,
+        `type` = ColumnType.PrimaryKey,
+        links = Vector(
+          Link(
+            tableName = new JadeIdentifier("sample"),
+            columnName = new JadeIdentifier("id")
+          )
+        )
+      ),
+      SimpleColumn(
+        name = new JadeIdentifier("file_type"),
+        datatype = DataType.String,
+        `type` = ColumnType.PrimaryKey
+      ),
+      SimpleColumn(
+        name = new JadeIdentifier("data_type"),
+        datatype = DataType.String,
+        `type` = ColumnType.Required
+      ),
+      SimpleColumn(
+        name = new JadeIdentifier("creation_date"),
+        datatype = DataType.Date
+      ),
+      SimpleColumn(
+        name = new JadeIdentifier("size"),
+        datatype = DataType.Integer
+      )
+    ),
+    structColumns = Vector(
+      StructColumn(
+        name = new JadeIdentifier("metrics"),
+        structName = new JadeIdentifier("file_metrics"),
+        `type` = ColumnType.Required
+      ),
+      StructColumn(
+        name = new JadeIdentifier("comments"),
+        structName = new JadeIdentifier("comments"),
+        `type` = ColumnType.Repeated
+      )
+    )
+  )
+
+  behavior of "BigQueryMetadataGenerator"
+
+  it should "translate table definitions to BQ schemas" in {
+    BigQueryMetadataGenerator.tableSchema(exampleTable) should contain allOf (
+      BigQueryColumn("sample_id", "STRING", "REQUIRED"),
+      BigQueryColumn("file_type", "STRING", "REQUIRED"),
+      BigQueryColumn("data_type", "STRING", "REQUIRED"),
+      BigQueryColumn("creation_date", "DATE", "NULLABLE"),
+      BigQueryColumn("size", "INT64", "NULLABLE"),
+      BigQueryColumn("metrics", "STRING", "REQUIRED"),
+      BigQueryColumn("comments", "STRING", "REPEATED")
+    )
+  }
+
+  it should "extract primary-key column names from table definitions" in {
+    BigQueryMetadataGenerator.primaryKeyColumns(exampleTable) should
+      contain allOf ("sample_id", "file_type")
+  }
+
+  it should "extract non-primary-key column names from table definitions" in {
+    BigQueryMetadataGenerator.nonPrimaryKeyColumns(exampleTable) should
+      contain allOf ("data_type", "creation_date", "size", "metrics", "comments")
+  }
+}


### PR DESCRIPTION
Every `MonsterJadeDatasetPlugin` project will publish a Docker image which:
1. Is based on the gcloud CLI (to give us `bq`), and
2. Per table, contains:
   1. A `schema.json` file containing a BQ-compatible schema definition
   2. A `primary-keys` file containing the comma-separated list of PKs in the table
   3. A `compare-cols` file containing the comma-separated list of non-PK columns in the table which should be diffed per ingest

These 3 files should give us the power to generate `bq query` calls like this:
```
bq query \
  --external_table_definition=${table}::/bq-metadata/${table}/schema.json \
  "SELECT J.datarepo_row_id, S.* FROM ${table} S OUTER JOIN ${jade_table} J \
   USING ($(cat /bq-metadata/${table}/primary-keys))"
```
(The compare-cols will be used in a `WHERE` clause above, but I still need to work out the details of the query)