### PR TITLE
DSPDC-940 Add support for table partition modes.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,12 +38,12 @@ lazy val `sbt-plugins-jade` = project
   .settings(
     commonSettings,
     libraryDependencies ++= Seq(
-      "com.beachape" %% "enumeratum" % "1.5.13",
-      "com.beachape" %% "enumeratum-circe" % "1.5.22",
-      "io.circe" %% "circe-core" % "0.12.3",
-      "io.circe" %% "circe-parser" % "0.12.3",
-      "io.circe" %% "circe-derivation" % "0.12.0-M7",
-      "org.scalatest" %% "scalatest" % "3.1.0" % Test
+      "com.beachape" %% "enumeratum" % "1.5.15",
+      "com.beachape" %% "enumeratum-circe" % "1.5.23",
+      "io.circe" %% "circe-core" % "0.13.0",
+      "io.circe" %% "circe-parser" % "0.13.0",
+      "io.circe" %% "circe-derivation" % "0.13.0-M4",
+      "org.scalatest" %% "scalatest" % "3.1.1" % Test
     )
   )
 

--- a/plugins/jade/src/main/scala/org/broadinstitute/monster/sbt/JadeDatasetGenerator.scala
+++ b/plugins/jade/src/main/scala/org/broadinstitute/monster/sbt/JadeDatasetGenerator.scala
@@ -144,12 +144,28 @@ object JadeDatasetGenerator {
         arrayOf = structCol.`type` == ColumnType.Repeated
       )
     }
+    val (mode, dateOpts, intOpts) = base.partitioning match {
+      case PartitionMode.IngestDate =>
+        (JadePartitionMode.Date, Some(JadeDatePartitionOptions.IngestDate), None)
+      case PartitionMode.DateFromColumn(col) =>
+        (JadePartitionMode.Date, Some(JadeDatePartitionOptions(col)), None)
+      case PartitionMode.IntRangeFromColumn(col, min, max, interval) =>
+        (
+          JadePartitionMode.Int,
+          None,
+          Some(JadeIntPartitionOptions(col, min, max, interval))
+        )
+    }
+
     JadeTable(
       name = base.name,
       columns = (simpleColumns ++ structColumns).toSet,
       primaryKey = base.columns.collect {
         case col if col.`type` == ColumnType.PrimaryKey => col.name
-      }.toSet
+      }.toSet,
+      partitionMode = mode,
+      datePartitionOptions = dateOpts,
+      intPartitionOptions = intOpts
     )
   }
 }

--- a/plugins/jade/src/main/scala/org/broadinstitute/monster/sbt/model/MonsterTable.scala
+++ b/plugins/jade/src/main/scala/org/broadinstitute/monster/sbt/model/MonsterTable.scala
@@ -13,7 +13,8 @@ import io.circe.derivation.{deriveDecoder, renaming}
 case class MonsterTable(
   name: JadeIdentifier,
   columns: Vector[SimpleColumn] = Vector.empty,
-  structColumns: Vector[StructColumn] = Vector.empty
+  structColumns: Vector[StructColumn] = Vector.empty,
+  partitioning: PartitionMode = PartitionMode.IngestDate
 )
 
 object MonsterTable {

--- a/plugins/jade/src/main/scala/org/broadinstitute/monster/sbt/model/PartitionMode.scala
+++ b/plugins/jade/src/main/scala/org/broadinstitute/monster/sbt/model/PartitionMode.scala
@@ -3,39 +3,52 @@ package org.broadinstitute.monster.sbt.model
 import io.circe.Decoder
 import io.circe.derivation.{deriveDecoder, renaming}
 
-/** TODO */
+/**
+  * Specification for how a Jade BigQuery table should be partitioned.
+  *
+  * Jade defaults to no partitioning for backwards compatibility, but
+  * BigQuery recommends that all tables be partitioned by *something*,
+  * so we don't expose that option here.
+  */
 sealed trait PartitionMode
 
 object PartitionMode {
-  /** TODO */
+  /**
+    * Partition rows by the date they were ingested into BigQuery.
+    *
+    * Jade's API merges this with the date-from-column partition mode,
+    * with a reserved string matching the name of the ingest-date column.
+    * We separate it into an entirely different option for max clarity.
+    */
   case object IngestDate extends PartitionMode
   implicit val ingestDateDecoder: Decoder[IngestDate.type] = deriveDecoder
 
   /**
-    * TODO
+    * Partition rows by the values of a DATE or TIMESTAMP column.
     *
-    * @param column
+    * @param column name of the column to partition on
     */
   case class DateFromColumn(column: JadeIdentifier) extends PartitionMode
   implicit val dateFromColumnDecoder: Decoder[DateFromColumn] = deriveDecoder
 
   /**
-    * TODO
+    * Partition rows by intervals of the values in an INTEGER column
     *
-    * @param column
-    * @param begin
-    * @param end
-    * @param interval
+    * @param column name of the column to partition on
+    * @param min smallest value to support in partitioning. A row with a value
+    *            smaller than this will land in the __UNPARTITIONED__ partition
+    * @param max largest value to support in partitioning. A row with a value
+    *            larger than this will land in the __UNPARTITIONED__ partition
+    * @param size size to use for the ranges that fall into each partition.
+    *             (max - min) / size must be <= 40K, or BigQuery will complain
     */
-  case class IntRangeFromColumn(
-    column: JadeIdentifier,
-    begin: Long,
-    end: Long,
-    interval: Long
-  ) extends PartitionMode
+  case class IntRangeFromColumn(column: JadeIdentifier, min: Long, max: Long, size: Long)
+      extends PartitionMode
   implicit val intRangeFromColumnDecoder: Decoder[IntRangeFromColumn] = deriveDecoder
 
-  /** TODO */
   implicit val modeDecoder: Decoder[PartitionMode] =
+    // NOTE: Some("mode") here establishes that any JSON object we attempt to
+    // decode into a PartitionMode must include a "mode" key, with a value matching
+    // the snake-case-ified name of one of the cases above.
     deriveDecoder(renaming.snakeCase, false, Some("mode"))
 }

--- a/plugins/jade/src/main/scala/org/broadinstitute/monster/sbt/model/PartitionMode.scala
+++ b/plugins/jade/src/main/scala/org/broadinstitute/monster/sbt/model/PartitionMode.scala
@@ -1,0 +1,41 @@
+package org.broadinstitute.monster.sbt.model
+
+import io.circe.Decoder
+import io.circe.derivation.{deriveDecoder, renaming}
+
+/** TODO */
+sealed trait PartitionMode
+
+object PartitionMode {
+  /** TODO */
+  case object IngestDate extends PartitionMode
+  implicit val ingestDateDecoder: Decoder[IngestDate.type] = deriveDecoder
+
+  /**
+    * TODO
+    *
+    * @param column
+    */
+  case class DateFromColumn(column: JadeIdentifier) extends PartitionMode
+  implicit val dateFromColumnDecoder: Decoder[DateFromColumn] = deriveDecoder
+
+  /**
+    * TODO
+    *
+    * @param column
+    * @param begin
+    * @param end
+    * @param interval
+    */
+  case class IntRangeFromColumn(
+    column: JadeIdentifier,
+    begin: Long,
+    end: Long,
+    interval: Long
+  ) extends PartitionMode
+  implicit val intRangeFromColumnDecoder: Decoder[IntRangeFromColumn] = deriveDecoder
+
+  /** TODO */
+  implicit val modeDecoder: Decoder[PartitionMode] =
+    deriveDecoder(renaming.snakeCase, false, Some("mode"))
+}

--- a/plugins/jade/src/main/scala/org/broadinstitute/monster/sbt/model/jadeapi/JadeDatePartitionOptions.scala
+++ b/plugins/jade/src/main/scala/org/broadinstitute/monster/sbt/model/jadeapi/JadeDatePartitionOptions.scala
@@ -1,0 +1,15 @@
+package org.broadinstitute.monster.sbt.model.jadeapi
+
+import io.circe.Encoder
+import io.circe.derivation.deriveEncoder
+import org.broadinstitute.monster.sbt.model.JadeIdentifier
+
+case class JadeDatePartitionOptions(column: JadeIdentifier)
+
+object JadeDatePartitionOptions {
+
+  val IngestDate: JadeDatePartitionOptions =
+    JadeDatePartitionOptions(new JadeIdentifier("daterepo_ingest_date"))
+
+  implicit val encoder: Encoder[JadeDatePartitionOptions] = deriveEncoder
+}

--- a/plugins/jade/src/main/scala/org/broadinstitute/monster/sbt/model/jadeapi/JadeIntPartitionOptions.scala
+++ b/plugins/jade/src/main/scala/org/broadinstitute/monster/sbt/model/jadeapi/JadeIntPartitionOptions.scala
@@ -1,0 +1,16 @@
+package org.broadinstitute.monster.sbt.model.jadeapi
+
+import io.circe.Encoder
+import io.circe.derivation.deriveEncoder
+import org.broadinstitute.monster.sbt.model.JadeIdentifier
+
+case class JadeIntPartitionOptions(
+  column: JadeIdentifier,
+  min: Long,
+  max: Long,
+  interval: Long
+)
+
+object JadeIntPartitionOptions {
+  implicit val encoder: Encoder[JadeIntPartitionOptions] = deriveEncoder
+}

--- a/plugins/jade/src/main/scala/org/broadinstitute/monster/sbt/model/jadeapi/JadePartitionMode.scala
+++ b/plugins/jade/src/main/scala/org/broadinstitute/monster/sbt/model/jadeapi/JadePartitionMode.scala
@@ -1,0 +1,15 @@
+package org.broadinstitute.monster.sbt.model.jadeapi
+
+import enumeratum.EnumEntry.Lowercase
+import enumeratum.{CirceEnum, Enum, EnumEntry}
+
+sealed trait JadePartitionMode extends EnumEntry with Lowercase
+
+object JadePartitionMode
+    extends Enum[JadePartitionMode]
+    with CirceEnum[JadePartitionMode] {
+  override val values = findValues
+
+  case object Date extends JadePartitionMode
+  case object Int extends JadePartitionMode
+}

--- a/plugins/jade/src/main/scala/org/broadinstitute/monster/sbt/model/jadeapi/JadeTable.scala
+++ b/plugins/jade/src/main/scala/org/broadinstitute/monster/sbt/model/jadeapi/JadeTable.scala
@@ -7,7 +7,10 @@ import org.broadinstitute.monster.sbt.model.JadeIdentifier
 case class JadeTable(
   name: JadeIdentifier,
   columns: Set[JadeColumn],
-  primaryKey: Set[JadeIdentifier]
+  primaryKey: Set[JadeIdentifier],
+  partitionMode: JadePartitionMode,
+  datePartitionOptions: Option[JadeDatePartitionOptions],
+  intPartitionOptions: Option[JadeIntPartitionOptions]
 )
 
 object JadeTable {

--- a/plugins/jade/src/test/scala/org/broadinstitute/monster/sbt/JadeDatasetGeneratorSpec.scala
+++ b/plugins/jade/src/test/scala/org/broadinstitute/monster/sbt/JadeDatasetGeneratorSpec.scala
@@ -29,6 +29,12 @@ class JadeDatasetGeneratorSpec extends AnyFlatSpec with Matchers with EitherValu
         name = new JadeIdentifier("attributes"),
         structName = new JadeIdentifier("donor_attributes")
       )
+    ),
+    partitioning = PartitionMode.IntRangeFromColumn(
+      column = new JadeIdentifier("age"),
+      begin = 0L,
+      end = 120L,
+      interval = 1L
     )
   )
 
@@ -85,6 +91,10 @@ class JadeDatasetGeneratorSpec extends AnyFlatSpec with Matchers with EitherValu
       SimpleColumn(
         name = new JadeIdentifier("path"),
         datatype = DataType.FileRef
+      ),
+      SimpleColumn(
+        name = new JadeIdentifier("creation_date"),
+        datatype = DataType.Date
       )
     ),
     structColumns = Vector(
@@ -98,7 +108,8 @@ class JadeDatasetGeneratorSpec extends AnyFlatSpec with Matchers with EitherValu
         structName = new JadeIdentifier("comments"),
         `type` = ColumnType.Repeated
       )
-    )
+    ),
+    partitioning = PartitionMode.DateFromColumn(new JadeIdentifier("creation_date"))
   )
 
   it should "build a Jade dataset from a collection of Monster tables" in {
@@ -129,7 +140,17 @@ class JadeDatasetGeneratorSpec extends AnyFlatSpec with Matchers with EitherValu
                 arrayOf = false
               )
             ),
-            primaryKey = Set(new JadeIdentifier("id"))
+            primaryKey = Set(new JadeIdentifier("id")),
+            partitionMode = JadePartitionMode.Int,
+            datePartitionOptions = None,
+            intPartitionOptions = Some {
+              JadeIntPartitionOptions(
+                column = new JadeIdentifier("age"),
+                min = 0L,
+                max = 120L,
+                interval = 1L
+              )
+            }
           ),
           JadeTable(
             name = samples.name,
@@ -150,7 +171,10 @@ class JadeDatasetGeneratorSpec extends AnyFlatSpec with Matchers with EitherValu
                 arrayOf = true
               )
             ),
-            primaryKey = Set(new JadeIdentifier("id"))
+            primaryKey = Set(new JadeIdentifier("id")),
+            partitionMode = JadePartitionMode.Date,
+            datePartitionOptions = Some(JadeDatePartitionOptions.IngestDate),
+            intPartitionOptions = None
           ),
           JadeTable(
             name = files.name,
@@ -184,10 +208,19 @@ class JadeDatasetGeneratorSpec extends AnyFlatSpec with Matchers with EitherValu
                 name = new JadeIdentifier("path"),
                 datatype = DataType.FileRef,
                 arrayOf = false
+              ),
+              JadeColumn(
+                name = new JadeIdentifier("creation_date"),
+                datatype = DataType.Date,
+                arrayOf = false
               )
             ),
             primaryKey =
-              Set(new JadeIdentifier("sample_id"), new JadeIdentifier("file_type"))
+              Set(new JadeIdentifier("sample_id"), new JadeIdentifier("file_type")),
+            partitionMode = JadePartitionMode.Date,
+            datePartitionOptions =
+              Some(JadeDatePartitionOptions(new JadeIdentifier("creation_date"))),
+            intPartitionOptions = None
           )
         ),
         relationships = Set(

--- a/plugins/jade/src/test/scala/org/broadinstitute/monster/sbt/JadeDatasetGeneratorSpec.scala
+++ b/plugins/jade/src/test/scala/org/broadinstitute/monster/sbt/JadeDatasetGeneratorSpec.scala
@@ -32,9 +32,9 @@ class JadeDatasetGeneratorSpec extends AnyFlatSpec with Matchers with EitherValu
     ),
     partitioning = PartitionMode.IntRangeFromColumn(
       column = new JadeIdentifier("age"),
-      begin = 0L,
-      end = 120L,
-      interval = 1L
+      min = 0L,
+      max = 120L,
+      size = 1L
     )
   )
 

--- a/plugins/jade/src/test/scala/org/broadinstitute/monster/sbt/model/PartitionModeSpec.scala
+++ b/plugins/jade/src/test/scala/org/broadinstitute/monster/sbt/model/PartitionModeSpec.scala
@@ -1,0 +1,30 @@
+package org.broadinstitute.monster.sbt.model
+
+import io.circe.jawn.JawnParser
+import org.scalatest.EitherValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class PartitionModeSpec extends AnyFlatSpec with Matchers with EitherValues {
+  behavior of "PartitionMode"
+
+  private val parser = new JawnParser()
+
+  it should "deserialize ingest_date modes" in {
+    val modeJson = """{ "mode": "ingest_date" }"""
+    parser.decode[PartitionMode](modeJson).right.value shouldBe PartitionMode.IngestDate
+  }
+
+  it should "deserialize date_from_column modes" in {
+    val modeJson = """{ "mode": "date_from_column", "column": "foo" }"""
+    parser.decode[PartitionMode](modeJson).right.value shouldBe
+      PartitionMode.DateFromColumn(new JadeIdentifier("foo"))
+  }
+
+  it should "deserialize int_range_from_column modes" in {
+    val modeJson =
+      """{ "mode": "int_range_from_column", "column": "bar", "begin": 0, "end": 2, "interval": 1 }"""
+    parser.decode[PartitionMode](modeJson).right.value shouldBe
+      PartitionMode.IntRangeFromColumn(new JadeIdentifier("bar"), 0L, 2L, 1L)
+  }
+}

--- a/plugins/jade/src/test/scala/org/broadinstitute/monster/sbt/model/PartitionModeSpec.scala
+++ b/plugins/jade/src/test/scala/org/broadinstitute/monster/sbt/model/PartitionModeSpec.scala
@@ -23,7 +23,7 @@ class PartitionModeSpec extends AnyFlatSpec with Matchers with EitherValues {
 
   it should "deserialize int_range_from_column modes" in {
     val modeJson =
-      """{ "mode": "int_range_from_column", "column": "bar", "begin": 0, "end": 2, "interval": 1 }"""
+      """{ "mode": "int_range_from_column", "column": "bar", "min": 0, "max": 2, "size": 1 }"""
     parser.decode[PartitionMode](modeJson).right.value shouldBe
       PartitionMode.IntRangeFromColumn(new JadeIdentifier("bar"), 0L, 2L, 1L)
   }


### PR DESCRIPTION
Mostly type-fu boilerplate. Had to bump the version of circe we use to get a fix for snake-case-ifying class names.