### PR TITLE
DSPDC-797 First pass at a plugin for Helm charts.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ val commonSettings = Seq(
 lazy val `monster-sbt-plugins` = project
   .in(file("."))
   .settings(publish / skip := true)
-  .aggregate(`sbt-plugins-core`, `sbt-plugins-jade`, `sbt-plugins-scio`)
+  .aggregate(`sbt-plugins-core`, `sbt-plugins-jade`, `sbt-plugins-scio`, `sbt-plugins-helm`)
 
 /** 'Core' plugins for use across all Monster sbt projects. */
 lazy val `sbt-plugins-core` = project
@@ -53,3 +53,15 @@ lazy val `sbt-plugins-scio` = project
   .enablePlugins(MonsterLibraryPlugin)
   .dependsOn(`sbt-plugins-core`)
   .settings(commonSettings)
+
+/** Plugins for Monster sbt projects that contain Helm charts. */
+lazy val `sbt-plugins-helm` = project
+  .in(file("plugins/helm"))
+  .enablePlugins(MonsterLibraryPlugin)
+  .dependsOn(`sbt-plugins-core`)
+  .settings(
+    commonSettings,
+    libraryDependencies ++= Seq(
+      "io.circe" %% "circe-yaml" % "0.12.0"
+    )
+  )

--- a/plugins/helm/src/main/scala/org/broadinstitute/monster/sbt/MonsterHelmPlugin.scala
+++ b/plugins/helm/src/main/scala/org/broadinstitute/monster/sbt/MonsterHelmPlugin.scala
@@ -1,0 +1,99 @@
+package org.broadinstitute.monster.sbt
+
+import io.circe.{Json, yaml}
+import io.circe.yaml.syntax._
+import sbt._
+import sbt.Keys._
+import scala.sys.process._
+
+/**
+  * Plugin for projects which wrap a Helm chart.
+  *
+  * Managing Helm in sbt is kinda a stretch. The main benefits are:
+  *   1. Being able to inject the "official" version of the build into chart metadata
+  *   2. Being able to run a single "publish" command and have charts get pushed
+  *      along-side libraries and Docker images
+  */
+object MonsterHelmPlugin extends AutoPlugin {
+
+  override def requires: Plugins = MonsterBasePlugin
+
+  object autoImport extends MonsterHelmPluginKeys
+
+  import autoImport._
+
+  override def projectSettings: Seq[Def.Setting[_]] = Seq(
+    helmStagingDirectory := target.value / "helm",
+    helmChartOrganization := "broadinstitute",
+    helmChartRepository := "monster-helm",
+    packageHelmChart := {
+      // Assumes the project is a valid Helm chart.
+      val sourceDir = baseDirectory.value
+      val tmpDir = IO.createTemporaryDirectory
+      IO.copyDirectory(sourceDir, tmpDir)
+
+      // Inject the version and appVersion so packaging does the right thing.
+      val chartMetadata = sourceDir / "Chart.yaml"
+      val parsedMetadata = yaml.parser.parse(IO.read(chartMetadata)) match {
+        case Right(parsed) => parsed
+        case Left(err)     => sys.error(s"Could not parse $chartMetadata as YAML: ${err.getMessage}")
+      }
+      val realVersion = Json.fromString(version.value)
+      val updatedMetadata =
+        parsedMetadata.deepMerge(Json.obj("version" -> realVersion, "appVersion" -> realVersion))
+      IO.write(tmpDir / "Chart.yaml", updatedMetadata.asYaml.spaces2)
+
+      // Make sure the target directory isn't included in the chart package.
+      val ignores = sourceDir / ".helmignore"
+      val defaultIgnores = if (ignores.exists) IO.readLines(ignores) else Nil
+      val ignoresWithTarget = "target" :: defaultIgnores
+      IO.writeLines(tmpDir / ".helmignore", ignoresWithTarget)
+
+      // Use helm to package the staged template.
+      // Assumes helm is available on the local PATH.
+      val targetDir = helmStagingDirectory.value
+      IO.delete(targetDir)
+      IO.createDirectory(targetDir)
+
+      val packageCommand = Seq(
+        "helm",
+        "package",
+        tmpDir.getAbsolutePath(),
+        "--destination",
+        targetDir.getAbsolutePath()
+      )
+      val packageResult = Process(packageCommand).!
+      if (packageResult != 0) {
+        sys.error(s"`helm package` failed with exit code $packageResult")
+      }
+      targetDir
+    },
+    publish := Def.taskDyn {
+      if (isSnapshot.value) {
+        // Don't bother publishing SNAPSHOT releases, since we can
+        // always sync w/ Flux instead.
+        Def.task {}
+      } else {
+        Def.task {
+          val log = streams.value.log
+          val packagedDirectory = packageHelmChart.value
+          val org = helmChartOrganization.value
+          val repo = helmChartRepository.value
+
+          // Assumes chart-releaser is available on the local PATH,
+          // and that CR_TOKEN is in the environment.
+          val uploadCommand =
+            Seq("cr", "upload", "-o", org, "-r", repo, "-p", packagedDirectory.getAbsolutePath())
+
+          log.info(s"Uploading Helm chart for ${name.value} to $org/$repo...")
+          val uploadResult = Process(uploadCommand).!
+          if (uploadResult != 0) {
+            sys.error(s"`cr upload` failed with exit code $uploadResult")
+          }
+        }
+      }
+    }.value,
+    // Doesn't make sense to publish a Helm chart locally(?)
+    publishLocal := {}
+  )
+}

--- a/plugins/helm/src/main/scala/org/broadinstitute/monster/sbt/MonsterHelmPluginKeys.scala
+++ b/plugins/helm/src/main/scala/org/broadinstitute/monster/sbt/MonsterHelmPluginKeys.scala
@@ -1,0 +1,20 @@
+package org.broadinstitute.monster.sbt
+
+import sbt._
+
+trait MonsterHelmPluginKeys {
+
+  val helmStagingDirectory: SettingKey[File] = settingKey(
+    "Local directory where packaged Helm charts should be staged"
+  )
+
+  val helmChartOrganization: SettingKey[String] = settingKey(
+    "GitHub organization of the chart repository where Helm charts should be published"
+  )
+
+  val helmChartRepository: SettingKey[String] = settingKey(
+    "GitHub repository where Helm charts should be published"
+  )
+
+  val packageHelmChart: TaskKey[File] = taskKey("Package the project's Helm chart")
+}


### PR DESCRIPTION
The logic is based off of [this script](https://github.com/broadinstitute/monster-helm/blob/master/hack/publish-charts) from monster-helm. I made a few design choices to minimize the moving pieces:
1. Publish all releases to `monster-helm`, even if the chart is defined in another repo. We already have an access token to do this, so it avoids having to mess with the politics of the DataBiosphere org.
2. Only to the `helm package` and `cr upload` steps from sbt, leaving out `cr index`. The indexing process isn't really resilient to concurrent updates, so I wanted to centralize it. I'm going to make a ticket to set up a `cron` action in `monster-helm` to do nothing but update the index.