### PR TITLE
DSPDC-976 Generate a new Helm index as part of releasing charts.

### DIFF
--- a/plugins/helm/src/main/scala/org/broadinstitute/monster/sbt/MonsterHelmPlugin.scala
+++ b/plugins/helm/src/main/scala/org/broadinstitute/monster/sbt/MonsterHelmPlugin.scala
@@ -120,7 +120,7 @@ object MonsterHelmPlugin extends AutoPlugin {
         git("checkout", "gh-pages")
         IO.copy(List(indexTarget -> gitBase / "index.yaml"))
         git("add", "index.yaml")
-        git("commit", "-m", s"Update index ($version)")
+        git("commit", "-m", "Update index.")
         git("push", "-f", "origin", "gh-pages")
       }
 

--- a/plugins/helm/src/main/scala/org/broadinstitute/monster/sbt/MonsterHelmPlugin.scala
+++ b/plugins/helm/src/main/scala/org/broadinstitute/monster/sbt/MonsterHelmPlugin.scala
@@ -77,7 +77,7 @@ object MonsterHelmPlugin extends AutoPlugin {
 
       // Assumes chart-releaser is available on the local PATH,
       // and that CR_TOKEN is in the environment.
-      def cr(cmd: String, args: Map[String, String]): Unit = {
+      def cr(cmd: String, args: (String, String)*): Unit = {
         val fullCommand =
           "cr" :: cmd :: args.toList.flatMap { case (k, v) => List(k, v) }
         val result = Process(fullCommand).!
@@ -87,19 +87,17 @@ object MonsterHelmPlugin extends AutoPlugin {
       }
 
       log.info(s"Uploading Helm chart for ${name.value} to $org/$repo...")
-      cr("upload", Map("-o" -> org, "-r" -> repo, "-p" -> packageDir))
+      cr("upload", "-o" -> org, "-r" -> repo, "-p" -> packageDir)
 
       val indexSite = s"https://$org.github.io/$repo"
       log.info(s"Adding Helm chart for ${name.value} to index for $indexSite...")
       cr(
         "index",
-        Map(
-          "-c" -> indexSite,
-          "-o" -> org,
-          "-r" -> repo,
-          "-p" -> packageDir,
-          "-i" -> indexTarget.getAbsolutePath()
-        )
+        "-c" -> indexSite,
+        "-o" -> org,
+        "-r" -> repo,
+        "-p" -> packageDir,
+        "-i" -> indexTarget.getAbsolutePath()
       )
 
       val gitBase = (ThisBuild / baseDirectory).value

--- a/plugins/helm/src/main/scala/org/broadinstitute/monster/sbt/MonsterHelmPluginKeys.scala
+++ b/plugins/helm/src/main/scala/org/broadinstitute/monster/sbt/MonsterHelmPluginKeys.scala
@@ -8,6 +8,10 @@ trait MonsterHelmPluginKeys {
     "Local directory where packaged Helm charts should be staged"
   )
 
+  val helmChartLocalIndex: SettingKey[File] = settingKey(
+    "Local path where index.yaml should be generated on Helm releases"
+  )
+
   val helmChartOrganization: SettingKey[String] = settingKey(
     "GitHub organization of the chart repository where Helm charts should be published"
   )
@@ -17,4 +21,6 @@ trait MonsterHelmPluginKeys {
   )
 
   val packageHelmChart: TaskKey[File] = taskKey("Package the project's Helm chart")
+
+  val releaseHelmChart: TaskKey[Unit] = taskKey("Upload the project's Helm chart to GitHub")
 }


### PR DESCRIPTION
~We'll need to do some copy-paste for the code that commits the generated `index.yaml` to the `gh-pages` branch, because I don't think that works very well from within `sbt`.~

This now does all steps required to update the index, including git-fu.