### PR TITLE
DSPDC-987 Separate Helm upload from index.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,5 +53,6 @@ Eventually we intend to publish a higher-level template repository containing th
 | `MonsterDockerPlugin` | `sbt-plugins-core` | Settings for publishing to DSP's public GCR repository. |
 | `MonsterJadeDatasetPlugin` | `sbt-plugins-jade` | Settings for working with Jade datasets and publishing schema images to GCR. |
 | `MonsterScioPipelinePlugin` | `sbt-plugins-scio` | Settings for developing Scio projects and publishing runner images to GCR. |
+| `MonsterHelmPlugin` | `sbt-plugins-helm` | Settings for developing Helm charts and publishing charts to GitHub pages. |
 
 See the individual plugin directories for more documentation about each artifact.

--- a/plugins/helm/README.md
+++ b/plugins/helm/README.md
@@ -1,0 +1,50 @@
+# Helm Plugin
+The `MonsterHelmPlugin` bundled in this project provides tasks for packaging,
+uploading, and indexing Helm charts to repositories hosted by GitHub pages.
+Most of its business logic is delegated to `helm` and `chart-releaser`, so if
+you're working on a "pure" Helm chart you probably just want to use those tools.
+
+If you're working on a Helm chart that calls other tools from within the same project,
+this chart can provide value by:
+1. Wiring the `publish` task to also publish the Helm chart, along with any JARs / containers
+2. Adding some pre-processing logic to inject the git-based version of the whole
+   project into chart metadata before publishing
+
+In the future, we may extend this plugin to also `lint` / `template` charts
+as part of the `test` task.
+
+## Using the Plugin
+The plugin's existing tasks are intended to be used from a GitHub action (though
+they should also work fine locally). You'll need to configure git and install tools
+for the `publish` task to work correctly. The minimal set of required `steps` is:
+```yaml
+steps:
+  - uses: actions/checkout@v2
+  # Required to check out the `gh-pages` branch.
+  - name: Fetch full git history
+    run: git fetch --prune --unshallow
+  # Required to push updates to `gh-pages`.
+  - name: Configure git
+    run: |
+      git config user.name "$GITHUB_ACTOR"
+      git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+  # Required for sbt to work
+  - uses: olafurpg/setup-scala@v7
+    with:
+      java-version: graalvm@20.0.0
+  # Install Helm and chart-releaser
+  - uses: azure/setup-helm@v1
+    with:
+      version: 'latest'
+  - uses: broadinstitute/setup-chart-releaser@v1
+    with:
+      version: 'latest'
+  # Upload the chart, and reindex the repository
+  - name: Publish
+    run: sbt publish reindexHelmRepository
+    env:
+      CR_TOKEN: ${{ secrets.ChartReleaserToken }}
+```
+
+The `ChartReleaserToken` secret must contain a personal access token
+with "repo" scope, to support uploading new releases.

--- a/plugins/helm/src/main/scala/org/broadinstitute/monster/sbt/MonsterHelmPlugin.scala
+++ b/plugins/helm/src/main/scala/org/broadinstitute/monster/sbt/MonsterHelmPlugin.scala
@@ -139,9 +139,15 @@ object MonsterHelmPlugin extends AutoPlugin {
       val attemptPushingIndex = Try {
         git("checkout", "gh-pages")
         IO.copyFile(indexTarget, gitBase / "index.yaml")
-        git("add", "index.yaml")
-        git("commit", "-m", "Update index.")
-        git("push", "-f", "origin", "gh-pages")
+
+        val diffCode = Process(Seq("git", "diff", "--quiet"), gitBase).!
+        if (diffCode == 0) {
+          log.info(s"Index for $indexSite is unchanged")
+        } else {
+          git("add", "index.yaml")
+          git("commit", "-m", "Update index.")
+          git("push", "-f", "origin", "gh-pages")
+        }
       }
 
       attemptPushingIndex match {

--- a/plugins/helm/src/main/scala/org/broadinstitute/monster/sbt/MonsterHelmPlugin.scala
+++ b/plugins/helm/src/main/scala/org/broadinstitute/monster/sbt/MonsterHelmPlugin.scala
@@ -4,6 +4,7 @@ import io.circe.{Json, yaml}
 import io.circe.yaml.syntax._
 import sbt._
 import sbt.Keys._
+import sbt.nio.Keys._
 import scala.sys.process._
 import scala.util.{Failure, Success, Try}
 
@@ -23,71 +24,92 @@ object MonsterHelmPlugin extends AutoPlugin {
 
   import autoImport._
 
+  def packageChart(
+    chartRoot: File,
+    version: String,
+    targetDir: File
+  ): Unit = {
+    val tmpDir = IO.createTemporaryDirectory
+    IO.copyDirectory(chartRoot, tmpDir)
+    // Wipe out the target/ directory, if it was copied over.
+    IO.delete(tmpDir / "target")
+
+    // Inject the version and appVersion so packaging does the right thing.
+    val chartMetadata = chartRoot / "Chart.yaml"
+    val parsedMetadata = yaml.parser.parse(IO.read(chartMetadata)) match {
+      case Right(parsed) => parsed
+      case Left(err)     => sys.error(s"Could not parse $chartMetadata as YAML: ${err.getMessage}")
+    }
+    val realVersion = Json.fromString(version)
+    val updatedMetadata =
+      parsedMetadata.deepMerge(Json.obj("version" -> realVersion, "appVersion" -> realVersion))
+    IO.write(tmpDir / "Chart.yaml", updatedMetadata.asYaml.spaces2)
+
+    // Use helm to package the staged template.
+    // Assumes helm is available on the local PATH.
+    IO.delete(targetDir)
+    IO.createDirectory(targetDir)
+
+    val packageCommand = Seq(
+      "helm",
+      "package",
+      tmpDir.getAbsolutePath(),
+      "--destination",
+      targetDir.getAbsolutePath()
+    )
+    val packageResult = Process(packageCommand).!
+    if (packageResult != 0) {
+      sys.error(s"`helm package` failed with exit code $packageResult")
+    }
+  }
+
+  // Assumes chart-releaser is available on the local PATH,
+  // and that CR_TOKEN is in the environment.
+  def cr(cmd: String, args: (String, String)*): Unit = {
+    val fullCommand =
+      "cr" :: cmd :: args.toList.flatMap { case (k, v) => List(k, v) }
+    val result = Process(fullCommand).!
+    if (result != 0) {
+      sys.error(s"`cr $cmd` failed with exit code $result")
+    }
+  }
+
   override def projectSettings: Seq[Def.Setting[_]] = Seq(
     helmStagingDirectory := target.value / "helm",
     helmChartLocalIndex := helmStagingDirectory.value / "index.yaml",
+    packageHelmChart / fileInputs += baseDirectory.value.toGlob / **,
     packageHelmChart := {
-      // Assumes the project is a valid Helm chart.
-      val sourceDir = baseDirectory.value
-      val tmpDir = IO.createTemporaryDirectory
-      IO.copyDirectory(sourceDir, tmpDir)
+      val inputChanges = packageHelmChart.inputFileChanges
+      val targetDir = target.value.toPath
+      val filteredChanges = List
+        .concat(
+          inputChanges.created,
+          inputChanges.modified,
+          inputChanges.deleted
+        )
+        .filterNot(_.startsWith(targetDir))
 
-      // Inject the version and appVersion so packaging does the right thing.
-      val chartMetadata = sourceDir / "Chart.yaml"
-      val parsedMetadata = yaml.parser.parse(IO.read(chartMetadata)) match {
-        case Right(parsed) => parsed
-        case Left(err)     => sys.error(s"Could not parse $chartMetadata as YAML: ${err.getMessage}")
+      val packageTarget = helmStagingDirectory.value
+      if (filteredChanges.nonEmpty) {
+        packageChart(baseDirectory.value, version.value, packageTarget)
       }
-      val realVersion = Json.fromString(version.value)
-      val updatedMetadata =
-        parsedMetadata.deepMerge(Json.obj("version" -> realVersion, "appVersion" -> realVersion))
-      IO.write(tmpDir / "Chart.yaml", updatedMetadata.asYaml.spaces2)
-
-      // Make sure the target directory isn't included in the chart package.
-      val ignores = sourceDir / ".helmignore"
-      val defaultIgnores = if (ignores.exists) IO.readLines(ignores) else Nil
-      val ignoresWithTarget = "target" :: defaultIgnores
-      IO.writeLines(tmpDir / ".helmignore", ignoresWithTarget)
-
-      // Use helm to package the staged template.
-      // Assumes helm is available on the local PATH.
-      val targetDir = helmStagingDirectory.value
-      IO.delete(targetDir)
-      IO.createDirectory(targetDir)
-
-      val packageCommand = Seq(
-        "helm",
-        "package",
-        tmpDir.getAbsolutePath(),
-        "--destination",
-        targetDir.getAbsolutePath()
-      )
-      val packageResult = Process(packageCommand).!
-      if (packageResult != 0) {
-        sys.error(s"`helm package` failed with exit code $packageResult")
-      }
-      targetDir
+      packageTarget
     },
     releaseHelmChart := {
       val log = streams.value.log
       val packageDir = packageHelmChart.value.getAbsolutePath()
       val org = helmChartOrganization.value
       val repo = helmChartRepository.value
-      val indexTarget = helmChartLocalIndex.value
-
-      // Assumes chart-releaser is available on the local PATH,
-      // and that CR_TOKEN is in the environment.
-      def cr(cmd: String, args: (String, String)*): Unit = {
-        val fullCommand =
-          "cr" :: cmd :: args.toList.flatMap { case (k, v) => List(k, v) }
-        val result = Process(fullCommand).!
-        if (result != 0) {
-          sys.error(s"`cr $cmd` failed with exit code $result")
-        }
-      }
 
       log.info(s"Uploading Helm chart for ${name.value} to $org/$repo...")
       cr("upload", "-o" -> org, "-r" -> repo, "-p" -> packageDir)
+    },
+    reindexHelmRepository := {
+      val log = streams.value.log
+      val packageDir = packageHelmChart.value.getAbsolutePath()
+      val org = helmChartOrganization.value
+      val repo = helmChartRepository.value
+      val indexTarget = helmChartLocalIndex.value
 
       val indexSite = s"https://$org.github.io/$repo"
       log.info(s"Adding Helm chart for ${name.value} to index for $indexSite...")
@@ -116,7 +138,7 @@ object MonsterHelmPlugin extends AutoPlugin {
       log.info(s"Pushing updated index to $indexSite...")
       val attemptPushingIndex = Try {
         git("checkout", "gh-pages")
-        IO.copy(List(indexTarget -> gitBase / "index.yaml"))
+        IO.copyFile(indexTarget, gitBase / "index.yaml")
         git("add", "index.yaml")
         git("commit", "-m", "Update index.")
         git("push", "-f", "origin", "gh-pages")

--- a/plugins/helm/src/main/scala/org/broadinstitute/monster/sbt/MonsterHelmPluginKeys.scala
+++ b/plugins/helm/src/main/scala/org/broadinstitute/monster/sbt/MonsterHelmPluginKeys.scala
@@ -23,4 +23,8 @@ trait MonsterHelmPluginKeys {
   val packageHelmChart: TaskKey[File] = taskKey("Package the project's Helm chart")
 
   val releaseHelmChart: TaskKey[Unit] = taskKey("Upload the project's Helm chart to GitHub")
+
+  val reindexHelmRepository: TaskKey[Unit] = taskKey(
+    "Update the index.yaml for the project's Helm repository"
+  )
 }


### PR DESCRIPTION
The indexing steps involve switching between git branches, which can wreak havoc on the `publish` logic running for other sub-projects. Splitting out a separate task means we have to push more copy-paste boilerplate into our GH actions, but it's the easiest way to make things concurrency-safe.