### PR TITLE
Updating the ScioUtilsVersion to match latest release of monster-scio-utils (1.3.0)

### DIFF
--- a/plugins/scio/src/main/scala/org/broadinstitute/monster/sbt/MonsterScioPipelinePlugin.scala
+++ b/plugins/scio/src/main/scala/org/broadinstitute/monster/sbt/MonsterScioPipelinePlugin.scala
@@ -8,7 +8,7 @@ import sbt.Keys._
 object MonsterScioPipelinePlugin extends AutoPlugin {
   override def requires: Plugins = MonsterDockerPlugin
 
-  val ScioUtilsVersion = "1.3.0"
+  val ScioUtilsVersion = "1.3.1"
 
   override def projectSettings: Seq[Def.Setting[_]] = Seq(
     // Set best-practice compiler flags for Scio.

--- a/plugins/scio/src/main/scala/org/broadinstitute/monster/sbt/MonsterScioPipelinePlugin.scala
+++ b/plugins/scio/src/main/scala/org/broadinstitute/monster/sbt/MonsterScioPipelinePlugin.scala
@@ -8,7 +8,7 @@ import sbt.Keys._
 object MonsterScioPipelinePlugin extends AutoPlugin {
   override def requires: Plugins = MonsterDockerPlugin
 
-  val ScioUtilsVersion = "1.2.1"
+  val ScioUtilsVersion = "1.3.0"
 
   override def projectSettings: Seq[Def.Setting[_]] = Seq(
     // Set best-practice compiler flags for Scio.


### PR DESCRIPTION
Unit tests ran successfully and no errors when compiling.