### PR TITLE
Tweak settings to improve testability and (hopefully) fix test coverage

### DIFF
--- a/.github/workflows/build-and-publish-master.yaml
+++ b/.github/workflows/build-and-publish-master.yaml
@@ -18,10 +18,9 @@ jobs:
       - name: Compile
         run: sbt Compile/compile Test/compile
       - name: Test
-        run: sbt "set ThisBuild/coverageEnabled := true" test
-      - name: Aggregate coverage reports
-        run: sbt coverageAggregate
-      - uses: codecov/codecov-action@v1
+        run: sbt "set ThisBuild/coverageEnabled := true" test coverageAggregate
+      - name: Publish coverage
+        uses: codecov/codecov-action@v1
       - name: Publish
         env:
           ARTIFACTORY_USERNAME: ${{ secrets.ArtifactoryUsername }}

--- a/.github/workflows/validate-pull-request.yaml
+++ b/.github/workflows/validate-pull-request.yaml
@@ -16,7 +16,6 @@ jobs:
       - name: Compile
         run: sbt Compile/compile Test/compile
       - name: Test
-        run: sbt "set ThisBuild/coverageEnabled := true" test
-      - name: Aggregate coverage reports
-        run: sbt coverageAggregate
-      - uses: codecov/codecov-action@v1
+        run: sbt "set ThisBuild/coverageEnabled := true" test coverageAggregate
+      - name: Publish coverage
+        uses: codecov/codecov-action@v1

--- a/plugins/core/src/main/scala/org/broadinstitute/monster/sbt/MonsterBasePlugin.scala
+++ b/plugins/core/src/main/scala/org/broadinstitute/monster/sbt/MonsterBasePlugin.scala
@@ -21,6 +21,7 @@ object MonsterBasePlugin extends AutoPlugin {
   import BuildInfoPlugin.autoImport._
   import DynVerPlugin.autoImport._
   import ScalafmtPlugin.autoImport._
+  import ScoverageSbtPlugin.autoImport._
 
   // Automatically apply our base settings to every project.
   override def requires: Plugins =
@@ -149,9 +150,10 @@ object MonsterBasePlugin extends AutoPlugin {
         IntegrationTest / fork := true,
         // De-duplicate BuildInfo objects so our projects can depend on one another
         // without conflicts.
-        buildInfoPackage := (ThisBuild / organization).value,
+        buildInfoPackage := (ThisBuild / organization).value + ".buildinfo",
         buildInfoObject := name.value.split('-').map(_.capitalize).mkString + "BuildInfo",
-        buildInfoOptions += BuildInfoOption.BuildTime
+        // Exclude build-info objects from test coverage.
+        coverageExcludedPackages += buildInfoPackage.value
       )
     )
 }

--- a/plugins/core/src/main/scala/org/broadinstitute/monster/sbt/MonsterBasePlugin.scala
+++ b/plugins/core/src/main/scala/org/broadinstitute/monster/sbt/MonsterBasePlugin.scala
@@ -153,7 +153,8 @@ object MonsterBasePlugin extends AutoPlugin {
         buildInfoPackage := (ThisBuild / organization).value + ".buildinfo",
         buildInfoObject := name.value.split('-').map(_.capitalize).mkString + "BuildInfo",
         // Exclude build-info objects from test coverage.
-        coverageExcludedPackages += buildInfoPackage.value
+        // NOTE: This is a regex, so we have to escape all the dots.
+        coverageExcludedPackages := buildInfoPackage.value.replaceAllLiterally(".", "\\.") + ".*"
       )
     )
 }

--- a/plugins/jade/src/main/scala/org/broadinstitute/monster/sbt/model/ColumnType.scala
+++ b/plugins/jade/src/main/scala/org/broadinstitute/monster/sbt/model/ColumnType.scala
@@ -66,10 +66,10 @@ object ColumnType extends Enum[ColumnType] with CirceEnum[ColumnType] {
   case object Repeated extends ColumnType {
 
     override def modify(scalaType: String): String =
-      s"_root_.scala.Array[$scalaType]"
+      s"_root_.scala.collection.immutable.List[$scalaType]"
 
     override def getDefaultValue(scalaType: String): Option[String] =
-      Some(s"_root_.scala.Array.empty[$scalaType]")
+      Some(s"_root_.scala.collection.immutable.List.empty[$scalaType]")
 
     override val asBigQuery: String = "REPEATED"
     override val isRequired: Boolean = false

--- a/plugins/jade/src/test/scala/org/broadinstitute/monster/sbt/ClassGeneratorSpec.scala
+++ b/plugins/jade/src/test/scala/org/broadinstitute/monster/sbt/ClassGeneratorSpec.scala
@@ -281,7 +281,7 @@ class ClassGeneratorSpec extends AnyFlatSpec with Matchers with EitherValues {
     s"""package $testPackage
        |
        |case class ArrayColumn(
-       |testArray: _root_.scala.Array[_root_.scala.Double])
+       |testArray: _root_.scala.collection.immutable.List[_root_.scala.Double])
        |
        |object ArrayColumn {
        |  implicit val encoder: _root_.io.circe.Encoder[ArrayColumn] =
@@ -292,7 +292,7 @@ class ClassGeneratorSpec extends AnyFlatSpec with Matchers with EitherValues {
        |
        |  def init(): ArrayColumn = {
        |    ArrayColumn(
-       |      testArray = _root_.scala.Array.empty[_root_.scala.Double])
+       |      testArray = _root_.scala.collection.immutable.List.empty[_root_.scala.Double])
        |  }
        |}
        |""".stripMargin
@@ -328,7 +328,7 @@ class ClassGeneratorSpec extends AnyFlatSpec with Matchers with EitherValues {
        |case class AllModifiers(
        |keyColumn: _root_.java.time.LocalDate,
        |normalColumn: _root_.scala.Option[_root_.scala.Boolean],
-       |arrayColumn: _root_.scala.Array[_root_.scala.Long],
+       |arrayColumn: _root_.scala.collection.immutable.List[_root_.scala.Long],
        |requiredColumn: _root_.scala.Double)
        |
        |object AllModifiers {
@@ -344,7 +344,7 @@ class ClassGeneratorSpec extends AnyFlatSpec with Matchers with EitherValues {
        |    AllModifiers(
        |      keyColumn = keyColumn,
        |      normalColumn = _root_.scala.Option.empty[_root_.scala.Boolean],
-       |      arrayColumn = _root_.scala.Array.empty[_root_.scala.Long],
+       |      arrayColumn = _root_.scala.collection.immutable.List.empty[_root_.scala.Long],
        |      requiredColumn = requiredColumn)
        |  }
        |}
@@ -357,7 +357,7 @@ class ClassGeneratorSpec extends AnyFlatSpec with Matchers with EitherValues {
     """case class AllModifiers(
        keyColumn: _root_.java.time.LocalDate,
        normalColumn: _root_.scala.Option[_root_.scala.Boolean],
-       arrayColumn: _root_.scala.Array[_root_.scala.Long])
+       arrayColumn: _root_.scala.collection.immutable.List[_root_.scala.Long])
        """ should compile
   }
 
@@ -476,7 +476,7 @@ class ClassGeneratorSpec extends AnyFlatSpec with Matchers with EitherValues {
     s"""package $testPackage
        |
        |case class RepeatedStruct(
-       |repeatedComment: _root_.scala.Array[_root_.$structPackage.Comment123])
+       |repeatedComment: _root_.scala.collection.immutable.List[_root_.$structPackage.Comment123])
        |
        |object RepeatedStruct {
        |  implicit val encoder: _root_.io.circe.Encoder[RepeatedStruct] =
@@ -487,7 +487,7 @@ class ClassGeneratorSpec extends AnyFlatSpec with Matchers with EitherValues {
        |
        |  def init(): RepeatedStruct = {
        |    RepeatedStruct(
-       |      repeatedComment = _root_.scala.Array.empty[_root_.$structPackage.Comment123])
+       |      repeatedComment = _root_.scala.collection.immutable.List.empty[_root_.$structPackage.Comment123])
        |  }
        |}
        |""".stripMargin
@@ -686,7 +686,7 @@ class ClassGeneratorSpec extends AnyFlatSpec with Matchers with EitherValues {
     s"""package $structPackage
        |
        |case class ArrayField(
-       |testArray: _root_.scala.Array[_root_.scala.Double])
+       |testArray: _root_.scala.collection.immutable.List[_root_.scala.Double])
        |
        |object ArrayField {
        |  implicit val encoder: _root_.io.circe.Encoder[ArrayField] =
@@ -730,7 +730,7 @@ class ClassGeneratorSpec extends AnyFlatSpec with Matchers with EitherValues {
        |case class AllModifiers(
        |keyField: _root_.java.time.LocalDate,
        |normalField: _root_.scala.Option[_root_.scala.Boolean],
-       |arrayField: _root_.scala.Array[_root_.scala.Long],
+       |arrayField: _root_.scala.collection.immutable.List[_root_.scala.Long],
        |requiredField: _root_.scala.Double)
        |
        |object AllModifiers {
@@ -748,7 +748,7 @@ class ClassGeneratorSpec extends AnyFlatSpec with Matchers with EitherValues {
     """case class AllModifiers(
        keyField: _root_.java.time.LocalDate,
        normalField: _root_.scala.Option[_root_.scala.Boolean],
-       arrayField: _root_.scala.Array[_root_.scala.Long])
+       arrayField: _root_.scala.collection.immutable.List[_root_.scala.Long])
 
        object AllModifiers {
          implicit val encoder: _root_.io.circe.Encoder[AllModifiers] =

--- a/plugins/scio/src/main/scala/org/broadinstitute/monster/sbt/MonsterScioPipelinePlugin.scala
+++ b/plugins/scio/src/main/scala/org/broadinstitute/monster/sbt/MonsterScioPipelinePlugin.scala
@@ -8,7 +8,7 @@ import sbt.Keys._
 object MonsterScioPipelinePlugin extends AutoPlugin {
   override def requires: Plugins = MonsterDockerPlugin
 
-  val ScioUtilsVersion = "1.3.2"
+  val ScioUtilsVersion = "1.4.0"
 
   override def projectSettings: Seq[Def.Setting[_]] = Seq(
     // Set best-practice compiler flags for Scio.


### PR DESCRIPTION
1. Pull in the new monster-scio-utils version containing helpers to work with `List`
2. Change our codegen to use `List` instead of `Array`
3. Tweak our `sbt-buildinfo` and `sbt-scoverage` settings to write build-info objects into a dedicated package, ignored by code coverage.

The last point is random, but it's something that's bothered me for awhile. [This SO post](https://stackoverflow.com/questions/54349427/scoverage-combine-coverage-from-test-and-ittest) says that sbt-buildinfo + our style of testing can cause scoverage to fail to collect any coverage reports. I'm going to test collecting coverage in ClinVar with a `publishLocal` of the plugins to check if this fixes things.